### PR TITLE
Language, static files and middleware execution order

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "kth-style": "https://github.com/KTH/kth-style.git#v1.0.1",
     "kth-client-logging": "https://github.com/KTH/kth-client-logging.git#v1.0.0",
     "ldapjs": "^1.0.0",
+    "locale": "^0.1.0",
     "node-sass-middleware": "^0.9.8",
     "passport": "^0.3.2"
   },

--- a/server/controllers/systemCtrl.js
+++ b/server/controllers/systemCtrl.js
@@ -43,7 +43,7 @@ function _notFound (req, res, next) {
 function _final (err, req, res, next) {
   log.error({ err: err }, 'Unhandled error')
 
-  const statusCode = err.status || 500
+  const statusCode = err.status || err.statusCode || 500
   const isProd = (/prod/gi).test(process.env.NODE_ENV)
   const lang = language.getLanguage(res)
 

--- a/server/init/middleware/index.js
+++ b/server/init/middleware/index.js
@@ -8,17 +8,19 @@
 const log = require('kth-node-log')
 
 require('./crawlerRedirect')
+require('./accessLog')
+// The standard css transpiler is Sass but you can easily switch here
+// NOTE! that with the current code you can't run Sass and Less at the same time
+// Static resources should be handled first to avoid doing unnecessary work 
+require('./sass')
+require('./routing')
+
 require('./session')
 require('./parsers')
-require('./language')
-require('./accessLog')
-
-// The standard css transpiler is Sass but you can easily switch here
-// OBS that with the current code you can't run Sass and Less at the same time
-require('./sass')
-
-require('./routing')
+// casAuthentication should be as early as possible but needs parsers and session
 require('./casAuthentication')
+require('./language')
+
 require('./cortina')
 
 log.info('Middleware initialized')

--- a/server/init/middleware/language.js
+++ b/server/init/middleware/language.js
@@ -8,15 +8,14 @@ const language = require('../../util/language')
  * Middleware that checks for l-flag and stores its value in the session
  */
 function _setLanguage (req, res, next) {
-  if (/^\/static\/.*/.test(req.url)) {
-    // don't check language on static routes
-    next()
-    return
+  // Set locale if not already done by other middleware
+  // You can customise behaviour by adding middleware before this one
+  if (!res.locals.locale) {
+    language.init(req, res, req.query[ 'l' ])
   }
-
-  language.init(req, res, req.query[ 'l' ])
-
   next()
 }
 
-server.use(config.full.proxyPrefixPath.uri, _setLanguage)
+// Match all routes that aren't under the static directory
+const langRouteRegex = new RegExp('^' + config.full.proxyPrefixPath.uri + '/(?!static).*$', 'g')
+server.use(langRouteRegex, _setLanguage)

--- a/server/init/middleware/routing.js
+++ b/server/init/middleware/routing.js
@@ -44,6 +44,13 @@ server.use(config.full.proxyPrefixPath.uri + '/static/js/components', express.st
 server.use(config.full.proxyPrefixPath.uri + '/static/js', express.static(`./bundles/${getEnv()}`))
 // Map static content like images, css and js.
 server.use(config.full.proxyPrefixPath.uri + '/static', express.static('./public'))
+// Return 404 if static file isn't found so we don't go through the rest of the pipeline
+server.use(config.full.proxyPrefixPath.uri + '/static', function (req, res, next) {
+  var error = new Error('File not found: ' + req.originalUrl)
+  error.statusCode = 404
+  next(error)
+})
+
 
 // "case sensitive routing" tells Express whether /my-path is the same as /My-PaTH/
 // This is default false but I think better for SEO purposes, creating one canonical url.

--- a/server/util/language.js
+++ b/server/util/language.js
@@ -10,6 +10,7 @@ const locale = require('locale')
 const cookieName = 'language'
 const validLanguages = [ 'sv', 'en' ]
 const defaultLanguage = validLanguages[ 0 ]
+const supportedLocales = new locale.Locales(validLanguages, defaultLanguage)
 
 /**
  * Initialize locale and language for the current user session (respects cookie: language).
@@ -20,10 +21,10 @@ function _init (req, res, newLang) {
 
   if (lang) {
     let locales = new locale.Locales(lang, defaultLanguage)
-    chosenLocale = locales.best(validLanguages)
+    chosenLocale = locales.best(supportedLocales)
   } else {
     let locales = new locale.Locales(req.headers['accept-language'], defaultLanguage)
-    chosenLocale = locales.best(validLanguages)
+    chosenLocale = locales.best(supportedLocales)
   }
 
   // If we got an explicit language we set the language cookie
@@ -34,16 +35,20 @@ function _init (req, res, newLang) {
   res.locals.locale = chosenLocale
   // Backwards compatibility only in case someone accessed the prop directly:
   res.locals.language = chosenLocale.getLanguage
+
+  return chosenLocale
 }
 
 /**
  * Helper that gets the current language from the session
  */
 function _getLanguage (res) {
-  return res.locals.chosenLocale && res.locals.chosenLocale.language
+  return res.locals.locale && res.locals.locale.language
 }
 
 module.exports = {
   getLanguage: _getLanguage,
-  init: _init
+  init: _init,
+  validLanguages: validLanguages,
+  defaultLanguage: defaultLanguage
 }

--- a/server/util/language.js
+++ b/server/util/language.js
@@ -6,46 +6,41 @@
  */
 
 const log = require('kth-node-log')
+const locale = require('locale')
 const cookieName = 'language'
 const validLanguages = [ 'sv', 'en' ]
 const defaultLanguage = validLanguages[ 0 ]
 
-function _isValid (lang) {
-  return validLanguages.indexOf(lang) >= 0
-}
-
 /**
- * Initialize language for the current user session (cookie).
+ * Initialize locale and language for the current user session (respects cookie: language).
  */
 function _init (req, res, newLang) {
-  let lang = req.cookies[ cookieName ]
+  let lang = newLang || req.cookies[ cookieName ]
+  var chosenLocale
 
-  if (newLang && _isValid(newLang)) {
-    log.debug(`Language set from external source: '${newLang}'`)
-    res.cookie(cookieName, newLang)
-    lang = newLang
-  } else if (!lang || !_isValid(lang)) {
-    log.debug(`Language not set or invalid, setting default: '${defaultLanguage}'`)
-    res.cookie(cookieName, defaultLanguage)
-    lang = defaultLanguage
+  if (lang) {
+    let locales = new locale.Locales(lang, defaultLanguage)
+    chosenLocale = locales.best(validLanguages)
+  } else {
+    let locales = new locale.Locales(req.headers['accept-language'], defaultLanguage)
+    chosenLocale = locales.best(validLanguages)
   }
 
-  res.locals.language = lang
+  // If we got an explicit language we set the language cookie
+  if (newLang) {
+    res.cookie(cookieName, chosenLocale.language)
+  }
+
+  res.locals.locale = chosenLocale
+  // Backwards compatibility only in case someone accessed the prop directly:
+  res.locals.language = chosenLocale.getLanguage
 }
 
 /**
  * Helper that gets the current language from the session
  */
 function _getLanguage (res) {
-  const lang = res.locals.language
-
-  if (lang && _isValid(lang)) {
-    log.debug(`Language found: '${lang}'`)
-    return lang
-  }
-
-  log.debug(`Language not set, getting default: '${defaultLanguage}'`)
-  return defaultLanguage
+  return res.locals.chosenLocale && res.locals.chosenLocale.language
 }
 
 module.exports = {


### PR DESCRIPTION
- changed language handling to avoid surprises
- changed order of middleware to avoid activating session code when accessing static files
- return 404 when static files can't be found (was 500)