### PR TITLE
misc: Add CODEOWNERS with web-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@KTH/web-team


### PR DESCRIPTION
Testing the CODEOWNERS feature. The idea is that our team will be automatically added as reviewers when we open new PR:s.